### PR TITLE
Random fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+
+.env
+
+.git
+.gitignore
+
+Dockerfile
+.dockerignore
+
+README.md
+LICENSE
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci
 
 COPY . .
 

--- a/index.js
+++ b/index.js
@@ -10,6 +10,14 @@ intents: [
 
 })
 
+process.on('unhandledRejection', error => {
+	console.error('Unhandled promise rejection:', error);
+});
+
+client.on("shardError", error => {
+    console.error('A websocket connection encountered an error:', error);
+});
+
 client.on('ready', () => {
     console.log('the bot is online')
 })


### PR DESCRIPTION
- Log discord client errors
  Any network errors that discord.js experiences in the background will now be logged.
- Add .dockerignore
  When developing, there are a lot of files that get added to the project directory that should not be included in the docker image. Such as .env or the node_modules folder (the former because it contains secrets, the latter because it should be re-created in a clean docker container). The .dockerignore file is like .gitignore, but for Docker builds. Files specified there will not be copied to the docker image, and it also speeds up the Docker build because Docker does not have to process them before the build starts.
- Run `npm ci` instead of `npm install` in docker build
  There are situations where running `npm install` downloads slightly different versions of the packages specified in `package.json` and also updates `package-lock.json`. This is not a problem when developing, but it is undesirable during docker builds. `npm ci` never does this; it always installs the exact same package version specified in `package.json` and `package-lock.json`.