### PR TITLE
integrate dumb-init in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:18
 
+# dumb-init is a minimal process manager. We use it to ensure that signals from `docker stop` etc are properly handled.
+# https://github.com/Yelp/dumb-init
+# Without this, `docker stop` will take a long time to complete and eventually kills the app ungracefully.
+# This isn't a big problem for a simple bot but it can result in data corruption if the bot writes to files
+RUN DEBIAN_FRONTEND=noninteractive apt update && apt -y install dumb-init
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
There's an issue with the docker image right now, which is that the bot runs as PID 1 within the container. This causes the bot to not shut down in response to a signal such as INT or TERM, which means `docker stop` takes at least 10 seconds to complete. This may cause data corruption (if you ever add persistent data to the bot). Running as pid 1 also causes potential resource leaks.

To solve this problem I've added a tool called [dumb-init](https://github.com/Yelp/dumb-init) to the docker container which replaces the bot as pid 1. The bot will still work properly, and dumb-init fixes the aforementioned problem. The link I added contains an explanation of the problem and the fix.

(I've been dealing with this problem since I started dockerizing my apps but I never bothered investigating it until today. I'm applying this fix to all my projects.)